### PR TITLE
Migrate from master/slave vocabulary

### DIFF
--- a/ElimuPi_installer.py
+++ b/ElimuPi_installer.py
@@ -59,7 +59,7 @@ def install_usbmount():
     print "Install and configure automount"
     print "========================================="
     sudo("apt-get install usbmount ntfs-3g -y") or die("Unable to download usbmount")
-    sudo("sed -i '/MountFlags=slave/c\MountFlags=shared' /lib/systemd/system/systemd-udevd.service") or die ("Unable to update udevd configuration (systemd-udevd.service)")
+    sudo("sed -i '/MountFlags=subordinate/c\MountFlags=shared' /lib/systemd/system/systemd-udevd.service") or die ("Unable to update udevd configuration (systemd-udevd.service)")
     #sudo("rm * /etc/usbmount/mount.d; rm * /etc/usbmount/umount.d")
     #### Automount location /var/run/usbmount/<label>
     sudo("chmod +x ./build_elimupi/files/01_create_label_symlink ./build_elimupi/files/01_remove_model_symlink")


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.